### PR TITLE
feat: Add post type and pill view

### DIFF
--- a/yahn.xcodeproj/project.pbxproj
+++ b/yahn.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		9837FBE02480B10400BB7F99 /* ParentStoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9837FBDF2480B10400BB7F99 /* ParentStoriesView.swift */; };
 		9837FBE22480B55400BB7F99 /* ParentStoriesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9837FBE12480B55400BB7F99 /* ParentStoriesViewModel.swift */; };
 		9837FBE42480BB2800BB7F99 /* PageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9837FBE32480BB2800BB7F99 /* PageType.swift */; };
+		9837FBE624813F4200BB7F99 /* PillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9837FBE524813F4200BB7F99 /* PillView.swift */; };
+		9837FBE8248143E100BB7F99 /* View+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9837FBE7248143E100BB7F99 /* View+Extensions.swift */; };
 		9845446524778C6F00B4AD83 /* Color+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9845446424778C6F00B4AD83 /* Color+Extensions.swift */; };
 		984544682477950B00B4AD83 /* SecondaryButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984544672477950B00B4AD83 /* SecondaryButtonStyle.swift */; };
 		9845446C24779C8400B4AD83 /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9845446B24779C8400B4AD83 /* SafariView.swift */; };
@@ -77,6 +79,8 @@
 		9837FBDF2480B10400BB7F99 /* ParentStoriesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentStoriesView.swift; sourceTree = "<group>"; };
 		9837FBE12480B55400BB7F99 /* ParentStoriesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentStoriesViewModel.swift; sourceTree = "<group>"; };
 		9837FBE32480BB2800BB7F99 /* PageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageType.swift; sourceTree = "<group>"; };
+		9837FBE524813F4200BB7F99 /* PillView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillView.swift; sourceTree = "<group>"; };
+		9837FBE7248143E100BB7F99 /* View+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extensions.swift"; sourceTree = "<group>"; };
 		9845446424778C6F00B4AD83 /* Color+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extensions.swift"; sourceTree = "<group>"; };
 		984544672477950B00B4AD83 /* SecondaryButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryButtonStyle.swift; sourceTree = "<group>"; };
 		9845446B24779C8400B4AD83 /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
@@ -225,6 +229,7 @@
 				9845446B24779C8400B4AD83 /* SafariView.swift */,
 				98905BA724799443003BB6C6 /* CommentView.swift */,
 				98905BA92479FD92003BB6C6 /* HeaderView.swift */,
+				9837FBE524813F4200BB7F99 /* PillView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -242,6 +247,7 @@
 			isa = PBXGroup;
 			children = (
 				9845446424778C6F00B4AD83 /* Color+Extensions.swift */,
+				9837FBE7248143E100BB7F99 /* View+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -510,6 +516,7 @@
 				98905BA424798D6E003BB6C6 /* CommentsViewModel.swift in Sources */,
 				988A63552476C9B900FFDC6B /* Story.swift in Sources */,
 				9837FBE22480B55400BB7F99 /* ParentStoriesViewModel.swift in Sources */,
+				9837FBE624813F4200BB7F99 /* PillView.swift in Sources */,
 				984544682477950B00B4AD83 /* SecondaryButtonStyle.swift in Sources */,
 				9845446C24779C8400B4AD83 /* SafariView.swift in Sources */,
 				980A4AFB2475980800148FBD /* StoryView.swift in Sources */,
@@ -523,6 +530,7 @@
 				9837FBE42480BB2800BB7F99 /* PageType.swift in Sources */,
 				980A4AC324757E5100148FBD /* SceneDelegate.swift in Sources */,
 				98905BA824799443003BB6C6 /* CommentView.swift in Sources */,
+				9837FBE8248143E100BB7F99 /* View+Extensions.swift in Sources */,
 				980A4AF7247590EC00148FBD /* HNWorker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/yahn/Extensions/View+Extensions.swift
+++ b/yahn/Extensions/View+Extensions.swift
@@ -1,0 +1,22 @@
+//
+//  View+Extensions.swift
+//  yahn
+//
+//  Created by Faiz Mokhtar on 29/05/2020.
+//  Copyright © 2020 Faiz Mokhtar. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+extension View {
+
+    /// Conditionally apply view modifiers
+    @ViewBuilder func `if`<T>(_ condition: Bool, transform: (Self) -> T) -> some View where T : View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
+    }
+}

--- a/yahn/Models/Story.swift
+++ b/yahn/Models/Story.swift
@@ -8,6 +8,12 @@
 
 import Foundation
 
+enum StoryType: String {
+    case news
+    case asks = "ask hn"
+    case jobs
+}
+
 struct Story: Identifiable {
     let id: String
     let title: String
@@ -17,4 +23,5 @@ struct Story: Identifiable {
     let username: String
     let relativeTime: String
     let commentCount: Int
+    let type: StoryType
 }

--- a/yahn/Scenes/Comments/CommentsView.swift
+++ b/yahn/Scenes/Comments/CommentsView.swift
@@ -30,7 +30,7 @@ struct CommentsView: View {
 }
 
 struct CommentsView_Previews: PreviewProvider {
-    static let story = Story(id: "123", title: "Ask HN: Is SwiftUI any good?", url: nil, domain: "swift.apple.com", points: 42, username: "faizmokhtar", relativeTime: "2 hours ago", commentCount: 69)
+    static let story = Story(id: "123", title: "Ask HN: Is SwiftUI any good?", url: nil, domain: "swift.apple.com", points: 42, username: "faizmokhtar", relativeTime: "2 hours ago", commentCount: 69, type: .news)
 
     static var previews: some View {
         CommentsView(viewModel: CommentsViewModel(story: story))

--- a/yahn/Views/HeaderView.swift
+++ b/yahn/Views/HeaderView.swift
@@ -67,7 +67,7 @@ struct HeaderView: View {
 }
 
 struct HeaderView_Previews: PreviewProvider {
-    static let story = Story(id: "123", title: "Ask HN: Is SwiftUI any good?", url: nil, domain: "swift.apple.com", points: 42, username: "faizmokhtar", relativeTime: "2 hours ago", commentCount: 69)
+    static let story = Story(id: "123", title: "Ask HN: Is SwiftUI any good?", url: nil, domain: "swift.apple.com", points: 42, username: "faizmokhtar", relativeTime: "2 hours ago", commentCount: 69, type: .news)
 
     static var previews: some View {
         HeaderView(story: story)

--- a/yahn/Views/PillView.swift
+++ b/yahn/Views/PillView.swift
@@ -1,0 +1,41 @@
+//
+//  PillView.swift
+//  yahn
+//
+//  Created by Faiz Mokhtar on 29/05/2020.
+//  Copyright © 2020 Faiz Mokhtar. All rights reserved.
+//
+
+import SwiftUI
+
+struct PillView: View {
+
+    let type: StoryType
+
+    var body: some View {
+        Text(type.rawValue.uppercased())
+            .font(.caption)
+            .fontWeight(.bold)
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .foregroundColor(.white)
+            .if(type == .jobs) {
+                $0.background(Color.blue)
+            }
+            .if(type == .asks) {
+                $0.background(Color.orange)
+            }
+            .cornerRadius(20)
+    }
+}
+
+struct PillView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            PillView(type: .jobs)
+                .previewLayout(.fixed(width: 100, height:100))
+            PillView(type: .asks)
+                .previewLayout(.fixed(width: 100, height:100))
+        }
+    }
+}

--- a/yahn/Views/StoryView.swift
+++ b/yahn/Views/StoryView.swift
@@ -35,6 +35,10 @@ struct StoryView: View {
                 .fontWeight(.medium)
                 .foregroundColor(.gray)
                 .padding(.horizontal, 15)
+            if story.type == .asks || story.type == .jobs {
+                PillView(type: story.type)
+                    .padding(.horizontal, 15)
+            }
             Text("\(story.points) points by \(story.username) \(story.relativeTime) | \(story.commentCount) comments")
                 .font(.caption)
                 .fontWeight(.regular)
@@ -49,9 +53,18 @@ struct StoryView: View {
 }
 
 struct StoryView_Previews: PreviewProvider {
-    static let story = Story(id: "123", title: "Ask HN: Is SwiftUI any good?", url: nil, domain: "swift.apple.com", points: 42, username: "faizmokhtar", relativeTime: "2 hours ago", commentCount: 69)
+    static let ask = Story(id: "123", title: "Ask HN: Is SwiftUI any good?", url: nil, domain: "swift.apple.com", points: 42, username: "faizmokhtar", relativeTime: "2 hours ago", commentCount: 69, type: .asks)
+    static let story = Story(id: "123", title: "Apple Review Process", url: nil, domain: "swift.apple.com", points: 42, username: "faizmokhtar", relativeTime: "2 hours ago", commentCount: 69, type: .news)
+    static let jobs = Story(id: "123", title: "Apple Review Process", url: nil, domain: "swift.apple.com", points: 42, username: "faizmokhtar", relativeTime: "2 hours ago", commentCount: 69, type: .jobs)
+
     static var previews: some View {
-        StoryView(story: story)
-            .previewLayout(.sizeThatFits)
+        Group {
+            StoryView(story: story)
+                .previewLayout(.sizeThatFits)
+            StoryView(story: ask)
+                .previewLayout(.sizeThatFits)
+            StoryView(story: jobs)
+                .previewLayout(.sizeThatFits)
+        }
     }
 }

--- a/yahn/Workers/HNWorker.swift
+++ b/yahn/Workers/HNWorker.swift
@@ -33,7 +33,8 @@ class HNWorker {
                     points: post.points,
                     username: post.username,
                     relativeTime: post.time,
-                    commentCount: post.commentCount)
+                    commentCount: post.commentCount,
+                    type: self.getType(for: post))
                 stories.append(story)
                 completion(.success((stories, linkForMore)))
             }
@@ -56,7 +57,8 @@ class HNWorker {
                     points: post.points,
                     username: post.username,
                     relativeTime: post.time,
-                    commentCount: post.commentCount)
+                    commentCount: post.commentCount,
+                    type: self.getType(for: post))
                 stories.append(story)
             }
 
@@ -83,6 +85,17 @@ class HNWorker {
             }
 
             completion(.success(comments))
+        }
+    }
+
+    private func getType(for post: HNPost) -> StoryType {
+        switch post.type {
+        case .defaultType:
+            return .news
+        case .askHN:
+            return .asks
+        case .jobs:
+            return .jobs
         }
     }
 }


### PR DESCRIPTION
# What it does

This PR consist of the followings:
- Add post type `news`, `asks`, `jobs`
- Add pill view
- Add an extension to handle conditional view modifiers

<img width="283" alt="Screenshot 2020-05-29 at 9 23 33 PM" src="https://user-images.githubusercontent.com/1093100/83264937-67dec900-a1f3-11ea-8923-0b29d280c20f.png">

<img width="602" alt="Screenshot 2020-05-29 at 9 23 29 PM" src="https://user-images.githubusercontent.com/1093100/83264946-69a88c80-a1f3-11ea-943d-f94fabe44c14.png">
