### PR TITLE
fix: job post navigation

### DIFF
--- a/yahn/Scenes/Stories/StoriesView.swift
+++ b/yahn/Scenes/Stories/StoriesView.swift
@@ -11,6 +11,9 @@ import SwiftUI
 struct StoriesView: View {
 
     @ObservedObject var viewModel: StoriesViewModel
+
+    @State var isPresented: Bool = false
+
     private var selected: Int
 
     init(viewModel: StoriesViewModel, selected: Int = 0) {
@@ -22,9 +25,21 @@ struct StoriesView: View {
     var body: some View {
         List {
             ForEach(viewModel.stories) { story in
-                NavigationLink(destination:
-                CommentsView(viewModel: CommentsViewModel(story: story))) {
-                    StoryView(story: story)
+                if story.type != .jobs {
+                    NavigationLink(destination:
+                    CommentsView(viewModel: CommentsViewModel(story: story))) {
+                        StoryView(story: story)
+                    }
+                } else {
+                    Button(action: {
+                        self.isPresented.toggle()
+                    }) {
+                        Text("self")
+                        StoryView(story: story)
+                    }.sheet(isPresented: self.$isPresented) {
+                        guard let url = story.url else { return }
+                        SafariView(url: url)
+                    }
                 }
             }
             Button(action: viewModel.loadMore) {

--- a/yahn/Scenes/Stories/StoriesView.swift
+++ b/yahn/Scenes/Stories/StoriesView.swift
@@ -30,15 +30,14 @@ struct StoriesView: View {
                     CommentsView(viewModel: CommentsViewModel(story: story))) {
                         StoryView(story: story)
                     }
-                } else {
+                } else if story.url != nil {
                     Button(action: {
                         self.isPresented.toggle()
                     }) {
                         Text("self")
                         StoryView(story: story)
                     }.sheet(isPresented: self.$isPresented) {
-                        guard let url = story.url else { return }
-                        SafariView(url: url)
+                        SafariView(url: story.url!)
                     }
                 }
             }


### PR DESCRIPTION
# What it does

This PR consist of the followings:
- When opening a job post, it should present the safari view directly